### PR TITLE
Fix for vuepress-next@2.0.0-beta.43

### DIFF
--- a/src/client/SearchBox.vue
+++ b/src/client/SearchBox.vue
@@ -51,7 +51,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, computed } from "vue"
-import { useRouter } from "@vuepress/client"
+import { useRouter } from "vue-router"
 import { useSuggestions } from "./engine"
 
 export default defineComponent({

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export interface FullTextSearchPluginOptions {
     //
 }
 
-export const fullTextSearchPlugin: Plugin<FullTextSearchPluginOptions> =
+export const fullTextSearchPlugin: Plugin =
     fullTextSearchPluginFunction
 
 export default fullTextSearchPlugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,7 @@ export interface FullTextSearchPluginOptions {
     //
 }
 
-export const fullTextSearchPlugin: Plugin =
-    fullTextSearchPluginFunction
+export const fullTextSearchPlugin: Plugin = fullTextSearchPluginFunction
 
 export default fullTextSearchPlugin
 


### PR DESCRIPTION
Fix for vuepress-next@2.0.0-beta.43 because of [chore(client): do not re-export vue-router utils anymore](https://github.com/vuepress/vuepress-next/commit/ef75351337d382950ceb72aa1c3a2bc90acf6466) and [refactor: drop support for using bundler, theme and plugins by name](https://github.com/vuepress/vuepress-next/commit/b85b1c3b39e80a8de92a7469381061f75ef33623)